### PR TITLE
Use std::thread for coro::thread_pool (#221)

### DIFF
--- a/include/coro/thread_pool.hpp
+++ b/include/coro/thread_pool.hpp
@@ -201,7 +201,6 @@ public:
      */
     auto queue_size() const noexcept -> std::size_t
     {
-        // Might not be totally perfect but good enough, avoids acquiring the lock for now.
         std::atomic_thread_fence(std::memory_order::acquire);
         return m_queue.size();
     }
@@ -215,7 +214,7 @@ private:
     /// The configuration options.
     options m_opts;
     /// The background executor threads.
-    std::vector<std::jthread> m_threads;
+    std::vector<std::thread> m_threads;
 
     /// Mutex for executor threads to sleep on the condition variable.
     std::mutex m_wait_mutex;
@@ -225,10 +224,9 @@ private:
     std::deque<std::coroutine_handle<>> m_queue;
     /**
      * Each background thread runs from this function.
-     * @param stop_token Token which signals when shutdown() has been called.
      * @param idx The executor's idx for internal data structure accesses.
      */
-    auto executor(std::stop_token stop_token, std::size_t idx) -> void;
+    auto executor(std::size_t idx) -> void;
 
     /**
      * @param handle Schedules the given coroutine to be executed upon the first available thread.

--- a/src/io_scheduler.cpp
+++ b/src/io_scheduler.cpp
@@ -253,11 +253,10 @@ auto io_scheduler::process_events_execute(std::chrono::milliseconds timeout) -> 
                 // Process scheduled coroutines.
                 process_scheduled_execute_inline();
             }
-            else if (handle_ptr == m_shutdown_ptr)
-                [[unlikely]]
-                {
-                    // Nothing to do , just needed to wake-up and smell the flowers
-                }
+            else if (handle_ptr == m_shutdown_ptr) [[unlikely]]
+            {
+                // Nothing to do , just needed to wake-up and smell the flowers
+            }
             else
             {
                 // Individual poll task wake-up.


### PR DESCRIPTION
* Use std::thread for coro::thread_pool

* This change switches from std::jthread to std::thread for the coro::thread_pool
* This change is in support of emscripten support
* The thread pool executors will now drain the queue before re-entering the condition variable.

Closes #220